### PR TITLE
Re-enable db sort and return cheapest order on getOrderForItem

### DIFF
--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -34,7 +34,7 @@ export function Collection(props: any) {
       setListingIds(orders.map((o) => o.sell.amountOrId))
       setListingsTotal(total)
     })
-  }, [lastUpdate, sortFilter, page, collection])
+  }, [lastUpdate, sortFilter, page, collection, databaseStore])
 
   const { total, ids } = useMemo(() => {
     const filteredKnown = knownItems.filter((i) => !listingIds.find((c) => c.eq(i)))
@@ -49,12 +49,12 @@ export function Collection(props: any) {
     const endKnown = startKnown + count - listingIds.length
 
     return { ids: [...listingIds, ...filteredKnown.slice(startKnown, endKnown)], total }
-  }, [knownItems, listingIds, listingsTotal])
+  }, [knownItems, listingIds, listingsTotal, page])
 
   useEffect(() => {
     // Set to lowest first by default
     searchStore.setSortingFilter("low-high-price")
-  }, [])
+  }, [searchStore])
 
   useEffect(() => {
     setLoading(true)


### PR DESCRIPTION
Some items may have multiple orders created by the same owner, and both may be valid at the same time. The most relevant order for both the owner and possible buyers is the cheapest one. But we need to keep in mind some considerations:

- If the user sells an NFT and it has a second order, that second order will still be valid and it may be executed if the previous owner re-buys the token
- We should display this "multiple valid orders" exist for this token in the detail page
- When we sort for high to low price we are going to see some bad results, because the database will find both a high and low price listing for the same item